### PR TITLE
Unimplements dynamic http urls as it wasn't actually requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ class Recorder implements Flushable {
 
   --snip--
   URLConnectionReporter reporter = URLConnectionReporter.builder()
-                                                        .postUrl("http://localhost:9411/api/v1/spans")
+                                                        .endpoint("http://localhost:9411/api/v1/spans")
                                                         .build();
 
   Callback callback = new IncrementSpanMetricsCallback(metrics);


### PR DESCRIPTION
    I misunderstood a request from @nicmunroe about caching the URL and then
    pre-maturely implemented dynamic urls. In practice we've not had a
    request for dynamic URLs with URLConnection.
    
    Long story short: this undoes the fanciness as better sooner than later.